### PR TITLE
Conform to new vim test API

### DIFF
--- a/autoload/test/neovim_error_only.vim
+++ b/autoload/test/neovim_error_only.vim
@@ -1,11 +1,11 @@
 let s:buffer_suffix = ' # vim-test'
 
 function! test#neovim_error_only#strategy(cmd) abort
-  let l:options = {'on_exit': 's:on_exit_handler'}
+  let l:options = {'on_exit': function('s:on_exit_handler')}
 
   call s:close_buffer()
 
-  belowright new | call termopen(a:cmd . s:buffer_suffix, l:options)
+  belowright new | call termopen(a:cmd . s:buffer_suffix, l:options) | wincmd p
 endfunction
 
 function! s:close_buffer()
@@ -14,8 +14,17 @@ function! s:close_buffer()
   endif
 endfunction
 
-function! s:on_exit_handler(job_id, exit_code)
-  if a:exit_code == 0
-    call s:close_buffer()
+function! s:go_to_buffer()
+  if bufwinnr(s:buffer_suffix) != -1
+    execute bufwinnr(s:buffer_suffix) . 'wincmd w'
   endif
 endfunction
+
+function! s:on_exit_handler(job_id, exit_code, event)
+  if a:exit_code == 0
+    call s:close_buffer()
+  else
+    call s:go_to_buffer()
+  endif
+endfunction
+


### PR DESCRIPTION
The new vim test plugin expects custom test strategies to take
3 arguments instead of 2. This commit conforms to that new API as well
as makes sure the cursor jumps back to the current buffer while the tests are
running.