### PR TITLE
Feature/configure term position

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# neovim\_error\_only.vim
+# neovim_error_only.vim
 
 A custom [Neovim](https://neovim.io/) strategy for
 [test.vim](https://github.com/janko-m/vim-test) that reuses the terminal buffer
 for running tests and automatically close buffer on success.
-
 
 ## Setup
 
@@ -13,4 +12,16 @@ Plug 'kevinsjoberg/vim-test-neovim-error-only'
 
 " Tell test.vim to use strategy
 let g:test#strategy = 'neovim_error_only'
+```
+
+By default a split window will be opened on the bottom, but you can configure a
+diffrent position or orientation.
+
+Whatever you put here is passed to new - so, you may also specify size (see
+:help opening-window or :help new for more info):
+
+```vim
+let test#neovim_error_only#term_position = "topleft"
+let test#neovim_error_only#term_position = "vert"
+let test#neovim_error_only#term_position = "vert botright 30"
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# neovim_error_only.vim
+# neovim\_error\_only.vim
 
 A custom [Neovim](https://neovim.io/) strategy for
 [test.vim](https://github.com/janko-m/vim-test) that reuses the terminal buffer
@@ -15,7 +15,7 @@ let g:test#strategy = 'neovim_error_only'
 ```
 
 By default a split window will be opened on the bottom, but you can configure a
-diffrent position or orientation.
+different position or orientation.
 
 Whatever you put here is passed to new - so, you may also specify size (see
 :help opening-window or :help new for more info):

--- a/autoload/test/neovim_error_only.vim
+++ b/autoload/test/neovim_error_only.vim
@@ -1,11 +1,12 @@
 let s:buffer_suffix = ' # vim-test'
 
 function! test#neovim_error_only#strategy(cmd) abort
-  let l:options = {'on_exit': 's:on_exit_handler'}
+  let l:options = {'on_exit': function('s:on_exit_handler')}
+  let term_position = get(g:, 'test#neovim_error_only#term_position', 'botright')
 
   call s:close_buffer()
 
-  belowright new | call termopen(a:cmd . s:buffer_suffix, l:options)
+  execute term_position . ' new' | call termopen(a:cmd . s:buffer_suffix, l:options) | wincmd p
 endfunction
 
 function! s:close_buffer()
@@ -14,8 +15,16 @@ function! s:close_buffer()
   endif
 endfunction
 
-function! s:on_exit_handler(job_id, exit_code)
+function! s:go_to_buffer()
+  if bufwinnr(s:buffer_suffix) != -1
+    execute bufwinnr(s:buffer_suffix) . 'wincmd w'
+  endif
+endfunction
+
+function! s:on_exit_handler(job_id, exit_code, event)
   if a:exit_code == 0
     call s:close_buffer()
+  else
+    call s:go_to_buffer()
   endif
 endfunction


### PR DESCRIPTION
Add possibility to configure term position

Previously the termil would always be opened in a horizontal split.
This commit adds the flexibility to open in any way supported by the `new`
command.